### PR TITLE
fix: change help file to remove duplicate tags

### DIFF
--- a/doc/nvim-activate.txt
+++ b/doc/nvim-activate.txt
@@ -1,17 +1,17 @@
+*nvim-activate.txt*
 *nvim-activate*
+==============================================================================
+INTRODUCTION                                               *nvim-activate-intro*
+
+A plugin to display a reminder in the bottom-right corner of the editor to
+activate Neovim.
 
 Authors:  Tom Kuson <mail@tjkuson.me>
 Version:  NA
 Homepage: <https://github.com/tjkuson/nvim-activate>
 
 ==============================================================================
-INTRODUCTION                                                     *nvim-activate*
-
-A plugin to display reminder the bottom-right corner of the editor to
-activate Neovim.
-
-==============================================================================
-CONFIGURATION                                              *NvimActivate.config*
+CONFIGURATION                                             *nvim-activate-config*
 
 This plugin is intentionally minimal and has no options.
 


### PR DESCRIPTION
Had some trouble compiling on nix, it was failing a test due to duplicate help tags. Really easy fix, and not something I knew could even be a problem. Just edited the doc/nvim-activate.txt file to prevent that.

I really like this plugin, it's such a fun idea :p